### PR TITLE
Add the Accept-Encoding header to the cache key

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,12 +17,20 @@ var lru = require('tilestrata-lru');
 // set total size limit of cache
 server.layer('mylayer').route('tile.pbf')
     .use(/* some provider */)
-    .use(lru({size: '20mb' ttl: 30})); // ttl in seconds
+    .use(lru({size: '20mb', ttl: 30})); // ttl in seconds
 
 // or set a total number of items
 server.layer('mylayer').route('tile.pbf')
     .use(/* some provider */)
     .use(lru({size: 20, ttl: 30}));
+
+// set a function for the cache key
+server.layer('mylayer').route('tile.pbf')
+    .use(/* some provider */)
+    .use(lru({key: function(req) {
+        var compressed = /gzip|deflate/.test(req.headers['accept-encoding']) ? 1 : 0;
+        return req.z+','+req.x+','+req.y+','+req.layer+','+req.filename+','+compressed;
+    }}));
 ```
 
 ## Contributing

--- a/index.js
+++ b/index.js
@@ -1,12 +1,12 @@
 var SyncCache = require('active-cache/sync');
 var filesizeParser = require('filesize-parser');
 
-function key(req) {
-	return req.z+','+req.x+','+req.y+','+req.layer+','+req.filename+','+req.headers['accept-encoding'];
-}
-
 module.exports = function(opts) {
 	opts = opts || {};
+
+	var key = opts.key || function(req) {
+		return req.z+','+req.x+','+req.y+','+req.layer+','+req.filename;
+	};
 
 	var lruopts = {max: 6};
 	if (typeof opts.size === 'string') {

--- a/index.js
+++ b/index.js
@@ -2,7 +2,7 @@ var SyncCache = require('active-cache/sync');
 var filesizeParser = require('filesize-parser');
 
 function key(req) {
-	return req.z+','+req.x+','+req.y+','+req.layer+','+req.filename;
+	return req.z+','+req.x+','+req.y+','+req.layer+','+req.filename+','+req.headers['accept-encoding'];
 }
 
 module.exports = function(opts) {


### PR DESCRIPTION
This is necessary so that clients who request an uncompressed body won't get a gzip'ed result (and vice versa, but that would be less critical).

Note: There might be more headers to check for, because they might change the result body.
